### PR TITLE
Disable rules when fixing on save

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: node_js
 node_js:
   - 'node'
-before_script:
-  - bash <(curl -s https://raw.githubusercontent.com/wooorm/atom-travis/master/install.sh)
-  - export DISPLAY=":99"
+install:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 script:
-  - npm test
-  - npm run rebuild
-  - apm test
-env:
-  - CC=clang CXX=clang++ npm_config_clang=1
+  - npm rebuild
+  - npm run test
+addons:
+  apt:
+    packages:
+    - build-essential
+    - fakeroot
+    - git
+    - libsecret-1-dev

--- a/index.js
+++ b/index.js
@@ -28,8 +28,7 @@ export function activate() {
 		}
 	}));
 
-	this.subscriptions.add(
-		atom.workspace.observeTextEditors(editor => {
+	this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
 			editor.getBuffer().onWillSave(() => {
 				if (!atom.config.get('linter-xo.fixOnSave')) {
 					return;
@@ -43,8 +42,7 @@ export function activate() {
 
 				return fix(editor)(editor.getText());
 			});
-		})
-	);
+	}));
 }
 
 export const config = {

--- a/index.js
+++ b/index.js
@@ -29,19 +29,19 @@ export function activate() {
 	}));
 
 	this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
-			editor.getBuffer().onWillSave(() => {
-				if (!atom.config.get('linter-xo.fixOnSave')) {
-					return;
-				}
+		editor.getBuffer().onWillSave(() => {
+			if (!atom.config.get('linter-xo.fixOnSave')) {
+				return;
+			}
 
-				const {scopeName} = editor.getGrammar();
+			const {scopeName} = editor.getGrammar();
 
-				if (!SUPPORTED_SCOPES.includes(scopeName)) {
-					return;
-				}
+			if (!SUPPORTED_SCOPES.includes(scopeName)) {
+				return;
+			}
 
-				return fix(editor)(editor.getText());
-			});
+			return fix(editor)(editor.getText(), atom.config.get('linter-xo.rulesToDisableWhileFixingOnSave'));
+		});
 	}));
 }
 
@@ -49,6 +49,15 @@ export const config = {
 	fixOnSave: {
 		type: 'boolean',
 		default: false
+	},
+	rulesToDisableWhileFixingOnSave: {
+		title: 'Disable specific rules while fixing on save',
+		description: 'Prevent rules from being auto-fixed by XO. Applies to fixes made on save but not when running the `XO:Fix` command.',
+		type: 'array',
+		default: ['capitalized-comments', 'ava/no-only-test'],
+		items: {
+			type: 'string'
+		}
 	}
 };
 

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -5,7 +5,7 @@ import lint from './lint';
 export default function fix(editor) {
 	// (text: string) => Promise<void>
 	return (text, exclude) => {
-		const fix = exclude ? report => exclude.indexOf(report.ruleId) === -1 : true;
+		const fix = exclude ? report => !exclude.includes(report.ruleId) : true;
 		return lint(editor)(text, {fix})
 			.then(report => {
 				const [{output}] = report.results;

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -4,8 +4,9 @@ import lint from './lint';
 // (editor: Object) => function
 export default function fix(editor) {
 	// (text: string) => Promise<void>
-	return text => {
-		return lint(editor)(text, {fix: true})
+	return (text, exclude) => {
+		const fix = exclude ? report => exclude.indexOf(report.ruleId) === -1 : true;
+		return lint(editor)(text, {fix})
 			.then(report => {
 				const [{output}] = report.results;
 

--- a/lib/fix.test.js
+++ b/lib/fix.test.js
@@ -18,3 +18,12 @@ test('fix file with problems', async t => {
 	const expected = `console.log('Some problems.');\n`;
 	t.is(actual, expected, 'should fix output');
 });
+
+test('exclude rules from fixing', async t => {
+	const input = `//some uncapitalized comment`;
+	const editor = editors.enabled(input);
+	await fix(editor)(editor.getText(), ['capitalized-comments']);
+	const actual = editor.getText();
+	const expected = `// some uncapitalized comment\n`;
+	t.is(actual, expected, 'should fix output, but not capitalized the comment');
+});

--- a/lib/format.js
+++ b/lib/format.js
@@ -85,7 +85,8 @@ function selectPosition(editor, x) {
 	if (typeof x.endColumn === 'number' && typeof x.endLine === 'number') {
 		const msgCol = Math.max(0, x.column - 1);
 		return [[msgLine, msgCol], [x.endLine - 1, x.endColumn - 1]];
-	} else if (typeof x.line === 'number' && typeof x.column === 'number') {
+	}
+	if (typeof x.line === 'number' && typeof x.column === 'number') {
 		// We want msgCol to remain undefined if it was intentional so
 		// `generateRange` will give us a range over the entire line
 		const msgCol = typeof x.column === 'undefined' ? x.column : x.column - 1;

--- a/mocks/enabled/save-fixable-default.js
+++ b/mocks/enabled/save-fixable-default.js
@@ -1,0 +1,1 @@
+// uncapitalized comment

--- a/mocks/enabled/save-fixable.js
+++ b/mocks/enabled/save-fixable.js
@@ -1,0 +1,1 @@
+//Uncapitalized comment

--- a/mocks/index.js
+++ b/mocks/index.js
@@ -6,7 +6,9 @@ import MockEditor from './mock-editor';
 export const files = {
 	bad: getFile('bad'),
 	empty: getFile('empty'),
-	fixable: getFile('fixable')
+	fixable: getFile('fixable'),
+	saveFixable: getFile('save-fixable'),
+	saveFixableDefault: getFile('save-fixable-default')
 };
 
 export const paths = {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 	"scripts": {
 		"lint": "xo --ignore='mocks/**/*'",
 		"pretest": "npm run lint",
-		"rebuild": "electron-rebuild -v $(atom -v | grep Electron | sed -e 's/^Electron: //')",
 		"test": "ava"
 	},
 	"keywords": [
@@ -40,7 +39,6 @@
 	"devDependencies": {
 		"ava": "^0.19.1",
 		"babel-register": "^6.18.0",
-		"electron-rebuild": "^1.4.0",
 		"proxyquire": "^1.7.10",
 		"text-buffer": "^11.4.0",
 		"tmp": "0.0.31"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"p-props": "^1.0.0",
 		"pkg-dir": "^1.0.0",
 		"resolve-from": "^3.0.0",
-		"xo": "^0.18.0"
+		"xo": "^0.20.1"
 	},
 	"devDependencies": {
 		"ava": "^0.19.1",

--- a/spec.js
+++ b/spec.js
@@ -42,7 +42,7 @@ describe('xo provider for linter', () => {
 				expect(message.location.file).toEqual(files.bad);
 				expect(message.severity).toEqual('error');
 				expect(message.excerpt).toEqual('Strings must use singlequote.');
-				expect(message.url).toEqual('http://eslint.org/docs/rules/quotes');
+				expect(message.url).toEqual('https://eslint.org/docs/rules/quotes');
 			});
 		});
 	});
@@ -78,6 +78,37 @@ describe('xo provider for linter', () => {
 
 				const messages = await lint(fixed);
 				expect(messages.length).toBe(0);
+			});
+		});
+
+		it('exclude default rules configured in rulesToDisableWhileFixingOnSave', () => {
+			waitsForPromise(async () => {
+				atom.config.set('linter-xo.fixOnSave', true);
+				const expected = `// uncapitalized comment\n`;
+				const editor = await atom.workspace.open(files.saveFixableDefault);
+				editor.save();
+
+				const actual = editor.getText();
+				expect(actual).toBe(expected);
+
+				const messages = await lint(editor);
+				expect(messages.length).toBe(1);
+			});
+		});
+
+		it('exclude rules configured in rulesToDisableWhileFixingOnSave', () => {
+			waitsForPromise(async () => {
+				atom.config.set('linter-xo.fixOnSave', true);
+				atom.config.set('linter-xo.rulesToDisableWhileFixingOnSave', ['spaced-comment']);
+				const expected = `//Uncapitalized comment\n`;
+				const editor = await atom.workspace.open(files.saveFixable);
+				editor.save();
+
+				const actual = editor.getText();
+				expect(actual).toBe(expected);
+
+				const messages = await lint(editor);
+				expect(messages.length).toBe(1);
 			});
 		});
 

--- a/spec/linter-xo-spec.js
+++ b/spec/linter-xo-spec.js
@@ -1,8 +1,8 @@
 /** @babel */
 /* eslint-env atom, jasmine */
 /* global waitsForPromise */
-import {files} from './mocks';
-import {provideLinter} from '.';
+import {files} from '../mocks';
+import {provideLinter} from '..';
 
 describe('xo provider for linter', () => {
 	const {lint} = provideLinter();


### PR DESCRIPTION
Fix #89

Add a new config that allows to define rules that will not be automatically fixed when saving.
Set by default with [capitalized-comments](https://eslint.org/docs/rules/capitalized-comments) and [no-only-test](https://github.com/avajs/eslint-plugin-ava/blob/master/docs/rules/no-only-test.md).

Errors will still be fixed when running the command `XO:Fix`.

The test currently fails because an issue with [deep-assign](https://github.com/sindresorhus/deep-assign) in XO. When passing the `fix` as a function, `deep-assign` replaces it with `{}`.
Passing the option `{fix: () => {...}}` through `deep-assign` results in `{fix: {}}`.

This is fixed by [4f4de13](https://github.com/sindresorhus/xo/commit/4f4de133b3c015387efcc34ab579d54da9bc7e87), but this commit is not released yet. As soon a new version of XO is released the tests will work.