### PR TITLE
Fix bug preventing ignored files from saving

### DIFF
--- a/lib/fix.js
+++ b/lib/fix.js
@@ -8,10 +8,11 @@ export default function fix(editor) {
 		const fix = exclude ? report => !exclude.includes(report.ruleId) : true;
 		return lint(editor)(text, {fix})
 			.then(report => {
-				const [{output}] = report.results;
+				const [result] = report.results;
 
-				if (output) {
-					editor.getBuffer().setTextViaDiff(output);
+				// No results are returned when the file is ignored
+				if (result && result.output) {
+					editor.getBuffer().setTextViaDiff(result.output);
 				}
 			});
 	};


### PR DESCRIPTION
Fixes an error that occurs when trying to save an ignored file (e.g: a JavaScript file in a hidden folder). The error is completely breaking the ability to save ignored files.

```
Uncaught (in promise) TypeError: Cannot read property 'output' of undefined
    at /Users/rolandwarmerdam/.atom/packages/linter-xo/lib/fix.js:11:19
```