### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - 'node'
+env:
+  global:
+    - CC=clang
+    - CXX=clang++
 install:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh

--- a/lib/fix.test.js
+++ b/lib/fix.test.js
@@ -3,7 +3,7 @@ import {editors} from '../mocks';
 import fix from './fix';
 
 test('fix file without problems', async t => {
-	const input = `console.log('No problems.');\n`;
+	const input = 'console.log(\'No problems.\');\n';
 	const editor = editors.enabled(input);
 	await fix(editor)(editor.getText());
 	const actual = editor.getText();
@@ -11,19 +11,19 @@ test('fix file without problems', async t => {
 });
 
 test('fix file with problems', async t => {
-	const input = `console.log('Some problems.');;;`;
+	const input = 'console.log(\'Some problems.\');;;';
 	const editor = editors.enabled(input);
 	await fix(editor)(editor.getText());
 	const actual = editor.getText();
-	const expected = `console.log('Some problems.');\n`;
+	const expected = 'console.log(\'Some problems.\');\n';
 	t.is(actual, expected, 'should fix output');
 });
 
 test('exclude rules from fixing', async t => {
-	const input = `//some uncapitalized comment`;
+	const input = '//some uncapitalized comment';
 	const editor = editors.enabled(input);
 	await fix(editor)(editor.getText(), ['capitalized-comments']);
 	const actual = editor.getText();
-	const expected = `// some uncapitalized comment\n`;
+	const expected = '// some uncapitalized comment\n';
 	t.is(actual, expected, 'should fix output, but not capitalized the comment');
 });

--- a/lib/format.js
+++ b/lib/format.js
@@ -93,7 +93,7 @@ function selectPosition(editor, x) {
 
 		try {
 			return generateRange(editor, msgLine, msgCol);
-		} catch (error) {
+		} catch (_) {
 			throw new Error(`Failed getting range. This is most likely an issue with ESLint. (${x.ruleId} - ${x.message} at ${x.line}:${x.column})`);
 		}
 	}

--- a/lib/format.js
+++ b/lib/format.js
@@ -93,7 +93,7 @@ function selectPosition(editor, x) {
 
 		try {
 			return generateRange(editor, msgLine, msgCol);
-		} catch (err) {
+		} catch (error) {
 			throw new Error(`Failed getting range. This is most likely an issue with ESLint. (${x.ruleId} - ${x.message} at ${x.line}:${x.column})`);
 		}
 	}

--- a/lib/lint.test.js
+++ b/lib/lint.test.js
@@ -3,25 +3,25 @@ import {editors} from '../mocks';
 import lint from './lint';
 
 test('file without problems', async t => {
-	const editor = editors.enabled(`console.log('No problems.');\n`);
+	const editor = editors.enabled('console.log(\'No problems.\');\n');
 	const {results: [{messages}]} = await lint(editor)(editor.getText());
 	t.deepEqual(messages, [], 'it should report no errors');
 });
 
 test('file with a problem', async t => {
-	const editor = editors.enabled(`console.log('One problem');`);
+	const editor = editors.enabled('console.log(\'One problem\');');
 	const {results: [{messages}]} = await lint(editor)(editor.getText());
 	t.is(messages.length, 1, 'it should report one error if enabled');
 });
 
 test('file with a problem in delegated workspace', async t => {
-	const editor = editors.delegated(`console.log('One problem');`);
+	const editor = editors.delegated('console.log(\'One problem\');');
 	const {results: [{messages}]} = await lint(editor)(editor.getText());
 	t.is(messages.length, 1, 'it should report one error if delegated');
 });
 
 test('file with a problem in disabled workspace', async t => {
-	const editor = editors.disabled(`console.log('One problem');`);
+	const editor = editors.disabled('console.log(\'One problem\');');
 	const {results: [{messages}]} = await lint(editor)(editor.getText());
 	t.is(messages.length, 0, 'it should report no errors');
 });

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.6.0",
     "eslint-rule-documentation": "^1.0.0",
-    "load-json-file": "^4.0.0",
+    "load-json-file": "^5.1.0",
     "loophole": "^1.1.0",
     "p-props": "^1.0.0",
-    "pkg-dir": "^2.0.0",
+    "pkg-dir": "^3.0.0",
     "resolve-from": "^4.0.0",
-    "xo": "^0.20.1"
+    "xo": "^0.23.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",

--- a/spec/linter-xo-spec.js
+++ b/spec/linter-xo-spec.js
@@ -70,7 +70,7 @@ describe('xo provider for linter', () => {
 	describe('fixes fixable.js and', () => {
 		it('produces text without errors', () => {
 			waitsForPromise(async () => {
-				const expected = `const foo = 'bar';\n\nconsole.log(foo);\n\nconsole.log(foo);\n`;
+				const expected = 'const foo = \'bar\';\n\nconsole.log(foo);\n\nconsole.log(foo);\n';
 				const editor = await atom.workspace.open(files.fixable);
 				const fixed = await fix(editor);
 				const actual = fixed.getText();
@@ -84,7 +84,7 @@ describe('xo provider for linter', () => {
 		it('exclude default rules configured in rulesToDisableWhileFixingOnSave', () => {
 			waitsForPromise(async () => {
 				atom.config.set('linter-xo.fixOnSave', true);
-				const expected = `// uncapitalized comment\n`;
+				const expected = '// uncapitalized comment\n';
 				const editor = await atom.workspace.open(files.saveFixableDefault);
 				editor.save();
 
@@ -100,7 +100,7 @@ describe('xo provider for linter', () => {
 			waitsForPromise(async () => {
 				atom.config.set('linter-xo.fixOnSave', true);
 				atom.config.set('linter-xo.rulesToDisableWhileFixingOnSave', ['spaced-comment']);
-				const expected = `//Uncapitalized comment\n`;
+				const expected = '//Uncapitalized comment\n';
 				const editor = await atom.workspace.open(files.saveFixable);
 				editor.save();
 


### PR DESCRIPTION
Update `xo`, `pkg-dir` and `load-json-file` dependencies.
Fix linting errors due to new XO version.

It seems to solve https://github.com/avajs/eslint-plugin-ava/issues/210 in my environment. I'm not sure how. I think the esm error from `eslint-plugin-ava` is still worth investigating though.