### PR TITLE
Do not prevent Atom to save file if XO errors out

### DIFF
--- a/lib/lint.js
+++ b/lib/lint.js
@@ -45,7 +45,15 @@ export default function lint(editor) {
 						filename ? {filename, cwd} : {},
 						options
 					);
-					report = xo.lintText(source, opts);
+					try {
+						report = xo.lintText(source, opts);
+					} catch (error) {
+						console.error(error);
+						atom.notifications.addError(
+							'linter-xo:: Error while running XO!',
+							{detail: error.message, dismissable: true}
+						);
+					}
 				});
 
 				process.chdir(previous);


### PR DESCRIPTION
Catches XO errors and send an Atom notification instead of propagating the error.

This way if XO errors out, when linting on save, Atom will still save the file.

That's quite useful especially with https://github.com/standard-things/esm/issues/671 happening every time you open a fiel from a different project without reloading Atom...