### PR TITLE
Refactor typescript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 'node'
+  - '12'
+install: skip
+cache:
+  npm: false
 env:
   global:
     - CC=clang

--- a/lib/format.js
+++ b/lib/format.js
@@ -47,21 +47,21 @@ function selectLocation(editor, x) {
 
 // (editor: Object, message: Object) => Array<number>
 function selectPosition(editor, x) {
-	const msgLine = x.line - 1;
+	const messageLine = x.line - 1;
 
 	if (typeof x.endColumn === 'number' && typeof x.endLine === 'number') {
-		const msgCol = Math.max(0, x.column - 1);
-		return [[msgLine, msgCol], [x.endLine - 1, x.endColumn - 1]];
+		const messageColumn = Math.max(0, x.column - 1);
+		return [[messageLine, messageColumn], [x.endLine - 1, x.endColumn - 1]];
 	}
 
 	if (typeof x.line === 'number' && typeof x.column === 'number') {
 		// We want msgCol to remain undefined if it was intentional so
 		// `generateRange` will give us a range over the entire line
-		const msgCol = typeof x.column === 'undefined' ? x.column : x.column - 1;
+		const messageColumn = typeof x.column === 'undefined' ? x.column : x.column - 1;
 
 		try {
-			return generateRange(editor, msgLine, msgCol);
-		} catch (_) {
+			return generateRange(editor, messageLine, messageColumn);
+		} catch {
 			throw new Error(`Failed getting range. This is most likely an issue with ESLint. (${x.ruleId} - ${x.message} at ${x.line}:${x.column})`);
 		}
 	}

--- a/lib/get-package-path.js
+++ b/lib/get-package-path.js
@@ -21,7 +21,7 @@ async function findPackage(base) {
 async function loadPkg(file) {
 	try {
 		return await loadJsonFile(file);
-	} catch (_) {
+	} catch {
 		return DEFAULT_PACKAGE;
 	}
 }

--- a/lib/get-package-path.ts
+++ b/lib/get-package-path.ts
@@ -1,12 +1,12 @@
 /** @babel */
+import type {JsonObject} from 'type-fest';
 import path from 'path';
 import loadJsonFile from 'load-json-file';
 import pkgDir from 'pkg-dir';
 
 const DEFAULT_PACKAGE = {xo: false};
 
-// (base: string) => pkgPath: Promise<string>
-async function findPackage(base) {
+async function findPackage(base: string): Promise<string> {
 	const pkgPath = path.join(base, 'package.json');
 	const pkg = await loadPkg(pkgPath);
 
@@ -17,8 +17,7 @@ async function findPackage(base) {
 	return pkgPath;
 }
 
-// (file: string) => pkg: Promise<Object>
-async function loadPkg(file) {
+async function loadPkg(file: string): Promise<JsonObject> {
 	try {
 		return await loadJsonFile(file);
 	} catch {
@@ -26,8 +25,7 @@ async function loadPkg(file) {
 	}
 }
 
-// (base: string) => pkgPath: Promise<string>
-export default async function getPackagePath(base) {
+export default async function getPackagePath(base: string): Promise<string | null> {
 	const resolvedBase = await pkgDir(base);
 	return resolvedBase ? findPackage(resolvedBase) : null;
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"atom": ">=1.34.0"
 	},
 	"scripts": {
-		"lint": "xo --ignore='mocks/**/*'",
+		"lint": "tsc --build && xo --ignore='mocks/**/*'",
 		"pretest": "npm run lint",
 		"test": "ava"
 	},
@@ -26,22 +26,53 @@
 		"xo"
 	],
 	"dependencies": {
+		"@atom/babel7-transpiler": "^1.0.0-1",
+		"@babel/preset-env": "^7.12.1",
+		"@babel/preset-typescript": "^7.12.1",
 		"atom-linter": "^10.0.0",
 		"atom-package-deps": "^5.0.0",
 		"eslint-rule-documentation": "^1.0.0",
 		"load-json-file": "^5.1.0",
 		"p-props": "^1.0.0",
-		"pkg-dir": "^3.0.0",
+		"pkg-dir": "^5.0.0",
 		"resolve-from": "^4.0.0",
 		"xo": "^0.34.0"
 	},
 	"devDependencies": {
+		"@types/atom": "^1.40.5",
+		"@types/eslint": "^7.2.4",
+		"@types/jasmine": "^3.6.0",
+		"@types/text-buffer": "^13.0.4",
+		"@types/tmp": "^0.2.0",
 		"ava": "^3.13.0",
 		"esm": "^3.2.25",
 		"proxyquire": "^2.0.1",
 		"text-buffer": "^13.15.2",
-		"tmp": "0.0.33"
+		"tmp": "0.0.33",
+		"ts-node": "^9.0.0",
+		"typescript": "^4.0.5"
 	},
+	"atomTranspilers": [
+		{
+			"glob": "**/*.[jt]s",
+			"transpiler": "@atom/babel7-transpiler",
+			"options": {
+				"babel": {
+					"presets": [
+						"@babel/preset-typescript",
+						[
+							"@babel/preset-env",
+							{
+								"targets": {
+									"electron": "1.6.0"
+								}
+							}
+						]
+					]
+				}
+			}
+		}
+	],
 	"package-deps": [
 		"linter:2.0.0"
 	],
@@ -53,8 +84,12 @@
 		}
 	},
 	"ava": {
+		"extensions": [
+			"js",
+			"ts"
+		],
 		"require": [
-			"esm"
+			"ts-node/register"
 		]
 	},
 	"xo": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"p-props": "^1.0.0",
 		"pkg-dir": "^3.0.0",
 		"resolve-from": "^4.0.0",
-		"xo": "^0.24.0"
+		"xo": "^0.34.0"
 	},
 	"devDependencies": {
 		"ava": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
 		"xo": "^0.24.0"
 	},
 	"devDependencies": {
-		"@babel/register": "^7.0.0",
-		"ava": "^1.1.0",
+		"ava": "^3.13.0",
+		"esm": "^3.2.25",
 		"proxyquire": "^2.0.1",
 		"text-buffer": "^13.15.2",
 		"tmp": "0.0.33"
@@ -54,12 +54,7 @@
 	},
 	"ava": {
 		"require": [
-			"@babel/register"
-		]
-	},
-	"babel": {
-		"presets": [
-			"@ava/stage-4"
+			"esm"
 		]
 	},
 	"xo": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"allowJs": true,
+		"esModuleInterop": true,
+		"target": "es2017",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"noEmit": true,
+		"resolveJsonModule": true,
+		"strict": true
+	}
+}


### PR DESCRIPTION
I spent some more time with atom transpilers. There's an rfc, but doesn't look like there's much movement there https://github.com/atom/atom/pull/17681

This PR introduces https://github.com/atom/atom-babel7-transpiler, which means we can use modern babel presets, including

- https://babeljs.io/docs/en/babel-preset-env
- https://babeljs.io/docs/en/babel-preset-typescript

This allows us to keep es modules, contrary to my thinking in https://github.com/xojs/atom-linter-xo/pull/101#discussion_r513954646