### PR TITLE
Fix unparsable JSON

### DIFF
--- a/lib/get-package-path.js
+++ b/lib/get-package-path.js
@@ -1,16 +1,17 @@
 const path = require('path');
 const loadJsonFile = require('load-json-file');
-const pkgDir = require('pkg-dir');
+const pkgUp = require('pkg-up');
 
 const DEFAULT_PACKAGE = {xo: false};
 
 // (base: string) => pkgPath: Promise<string>
 async function findPackage(base) {
-	const pkgPath = path.join(base, 'package.json');
+	const pkgPath = await pkgUp({cwd: base});
 	const pkg = await loadPkg(pkgPath);
 
-	if (pkg.xo === false && base !== null) {
-		return findPackage(path.join(base, '..'));
+	if (pkg.xo === false && pkgPath !== null) {
+		const newBase = path.resolve(path.dirname(pkgPath), '..');
+		return getPackagePath(newBase);
 	}
 
 	return pkgPath;
@@ -27,8 +28,7 @@ async function loadPkg(file) {
 
 // (base: string) => pkgPath: Promise<string>
 async function getPackagePath(base) {
-	const resolvedBase = await pkgDir(base);
-	return resolvedBase ? findPackage(resolvedBase) : null;
+	return findPackage(base);
 }
 
 module.exports = getPackagePath;

--- a/lib/get-package-path.test.js
+++ b/lib/get-package-path.test.js
@@ -25,3 +25,8 @@ test('in nested workspace', async t => {
 	const expected = path.resolve(paths['delegated/enabled'], 'package.json');
 	t.is(actual, expected, 'it should return path to manifest in nested workspace');
 });
+
+test('in no workspace', async t => {
+	const actual = await getPackagePath('/');
+	t.is(actual, null, 'it should return null');
+});

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"eslint-rule-documentation": "^1.0.0",
 		"load-json-file": "^5.1.0",
 		"p-props": "^1.0.0",
-		"pkg-dir": "^3.0.0",
+		"pkg-up": "^3.1.0",
 		"resolve-from": "^4.0.0",
 		"xo": "^0.34.0"
 	},


### PR DESCRIPTION
When `package.json` contains a syntax error, `findPackage()` is called repetitively, as `base` is never `null`.

This uses https://github.com/sindresorhus/pkg-up, which does return `null` if a `package.json` file isn't found

Fixes #92