### PR TITLE
Add relative path spec

### DIFF
--- a/mocks/enabled/relative-path.js
+++ b/mocks/enabled/relative-path.js
@@ -1,0 +1,1 @@
+const someExport = require('./some-export');

--- a/mocks/enabled/some-export.js
+++ b/mocks/enabled/some-export.js
@@ -1,0 +1,1 @@
+module.exports = true;

--- a/mocks/index.js
+++ b/mocks/index.js
@@ -7,6 +7,7 @@ export const files = {
 	bad: getFile('bad'),
 	empty: getFile('empty'),
 	fixable: getFile('fixable'),
+	relativePath: getFile('relative-path'),
 	saveFixable: getFile('save-fixable'),
 	saveFixableDefault: getFile('save-fixable-default')
 };

--- a/spec/linter-xo-spec.js
+++ b/spec/linter-xo-spec.js
@@ -59,6 +59,15 @@ describe('xo provider for linter', () => {
 		});
 	});
 
+	describe('checks relative-path.js and', () => {
+		it('shows no error notifications', async () => {
+			const editor = await atom.workspace.open(files.relativePath);
+			await lint(editor);
+			const errorNotifications = atom.notifications.getNotifications().filter(notification => notification.getType() === 'error');
+			expect(errorNotifications.length).toBe(0);
+		});
+	});
+
 	describe('fixes fixable.js and', () => {
 		it('produces text without errors', async () => {
 			const expected = 'const foo = \'bar\';\n\nconsole.log(foo);\n\nconsole.log(foo);\n';

--- a/spec/linter-xo-spec.js
+++ b/spec/linter-xo-spec.js
@@ -59,7 +59,7 @@ describe('xo provider for linter', () => {
 		});
 	});
 
-	describe('checks relative-path.js and', () => {
+	xdescribe('checks relative-path.js and', () => {
 		it('shows no error notifications', async () => {
 			const editor = await atom.workspace.open(files.relativePath);
 			await lint(editor);


### PR DESCRIPTION
I've been able to reproduce the issue in #108 with a spec. Looks like the issue is a result of linting relative file paths

```
Error: The V8 platform used by this instance of Node does not support creating Workers
Occurred while linting /home/runner/work/atom-linter-xo/atom-linter-xo/mocks/enabled/relative-path.js:1
    at new Worker (internal/worker.js:105:21)
    at resolveGlobsSync (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/ava/eslint-plugin-helper.js:102:14)
    at Object.load (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/ava/eslint-plugin-helper.js:170:16)
    at Object.exports.loadAvaHelper (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint-plugin-ava/util.js:19:19)
    at validateImportPath (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint-plugin-ava/rules/no-import-test-files.js:31:21)
    at CallExpression (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint-plugin-ava/rules/no-import-test-files.js:58:5)
    at /home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/node-event-generator.js:256:26)
    at NodeEventGenerator.applySelectors (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/node-event-generator.js:285:22)
    at NodeEventGenerator.enterNode (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/node-event-generator.js:299:14)
    at CodePathAnalyzer.enterNode (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:711:23)
    at /home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/linter.js:954:32
    at Array.forEach (<anonymous>)
    at runRules (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/linter.js:949:15)
    at Linter._verifyWithoutProcessors (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/linter.js:1175:31)
    at Linter._verifyWithoutProcessors (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint-plugin-eslint-comments/lib/utils/patch.js:181:42)
    at Linter._verifyWithConfigArray (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/linter.js:1273:21)
    at Linter.verify (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/linter.js:1228:25)
    at Linter.verifyAndFix (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/linter/linter.js:1418:29)
    at verifyText (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/cli-engine/cli-engine.js:234:48)
    at CLIEngine.executeOnText (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/eslint/lib/cli-engine/cli-engine.js:896:26)
    at Object.lintText (/home/runner/work/atom-linter-xo/atom-linter-xo/node_modules/xo/index.js:91:24)
    at /home/runner/work/atom-linter-xo/atom-linter-xo/lib/lint.js:55:16
```