### PR TITLE
Remove usages of ESM syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-/** @babel */
-import {CompositeDisposable} from 'atom';
-import {install} from 'atom-package-deps';
-import fix from './lib/fix.js';
-import format from './lib/format.js';
-import lint from './lib/lint.js';
+const {CompositeDisposable} = require('atom');
+const {install} = require('atom-package-deps');
+const fix = require('./lib/fix.js');
+const format = require('./lib/format.js');
+const lint = require('./lib/lint.js');
 
 const SUPPORTED_SCOPES = [
 	'source.js',
@@ -13,7 +12,7 @@ const SUPPORTED_SCOPES = [
 	'source.tsx'
 ];
 
-export function activate() {
+module.exports.activate = function () {
 	install('linter-xo');
 
 	this.subscriptions = new CompositeDisposable();
@@ -45,9 +44,9 @@ export function activate() {
 			return fix(editor)(editor.getText(), atom.config.get('linter-xo.rulesToDisableWhileFixingOnSave'));
 		});
 	}));
-}
+};
 
-export const config = {
+module.exports.config = {
 	fixOnSave: {
 		type: 'boolean',
 		default: false
@@ -67,11 +66,11 @@ export const config = {
 	}
 };
 
-export function deactivate() {
+module.exports.deactivate = function () {
 	this.subscriptions.dispose();
-}
+};
 
-export function provideLinter() {
+module.exports.provideLinter = function () {
 	return {
 		name: 'XO',
 		grammarScopes: SUPPORTED_SCOPES,
@@ -82,4 +81,4 @@ export function provideLinter() {
 			return format(editor)(result);
 		}
 	};
-}
+};

--- a/lib/fix.test.js
+++ b/lib/fix.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
-import {editors} from '../mocks/index.js';
-import fix from './fix.js';
+const test = require('ava');
+const {editors} = require('../mocks/index.js');
+const fix = require('./fix.js');
 
 test('fix file without problems', async t => {
 	const input = 'console.log(\'No problems.\');\n';

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -1,7 +1,7 @@
-import test from 'ava';
-import proxyquire from 'proxyquire';
-import {Range} from 'text-buffer';
-import MockEditor from '../mocks/mock-editor.js';
+const test = require('ava');
+const proxyquire = require('proxyquire');
+const {Range} = require('text-buffer');
+const MockEditor = require('../mocks/mock-editor.js');
 
 const stubs = {
 	atom: {

--- a/lib/get-package-data.test.js
+++ b/lib/get-package-data.test.js
@@ -1,7 +1,7 @@
-import path from 'path';
-import test from 'ava';
-import {paths} from '../mocks/index.js';
-import getPackageData from './get-package-data.js';
+const path = require('path');
+const test = require('ava');
+const {paths} = require('../mocks/index.js');
+const getPackageData = require('./get-package-data.js');
 
 test('in enabled workspace', async t => {
 	const {name: actual} = await getPackageData(paths.enabled);

--- a/lib/get-package-path.test.js
+++ b/lib/get-package-path.test.js
@@ -1,7 +1,7 @@
-import path from 'path';
-import test from 'ava';
-import {paths} from '../mocks/index.js';
-import getPackagePath from './get-package-path.js';
+const path = require('path');
+const test = require('ava');
+const {paths} = require('../mocks/index.js');
+const getPackagePath = require('./get-package-path.js');
 
 test('in enabled workspace', async t => {
 	const actual = await getPackagePath(paths.enabled);

--- a/lib/get-xo.test.js
+++ b/lib/get-xo.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
-import {paths} from '../mocks/index.js';
-import getXO from './get-xo.js';
+const test = require('ava');
+const {paths} = require('../mocks/index.js');
+const getXO = require('./get-xo.js');
 
 test('in workspace with locally resolvable xo', async t => {
 	const xo = await getXO(paths.local);

--- a/lib/lint.test.js
+++ b/lib/lint.test.js
@@ -1,6 +1,6 @@
-import test from 'ava';
-import {editors} from '../mocks/index.js';
-import lint from './lint.js';
+const test = require('ava');
+const {editors} = require('../mocks/index.js');
+const lint = require('./lint.js');
 
 test('file without problems', async t => {
 	const editor = editors.enabled('console.log(\'No problems.\');\n');

--- a/mocks/index.js
+++ b/mocks/index.js
@@ -1,9 +1,8 @@
-/** @babel */
-import path from 'path';
-import tmp from 'tmp';
-import MockEditor from './mock-editor';
+const path = require('path')
+const tmp = require('tmp')
+const MockEditor = require('./mock-editor')
 
-export const files = {
+module.exports.files = {
 	bad: getFile('bad'),
 	empty: getFile('empty'),
 	fixable: getFile('fixable'),
@@ -12,7 +11,7 @@ export const files = {
 	saveFixableDefault: getFile('save-fixable-default')
 };
 
-export const paths = {
+module.exports.paths = {
 	disabled: getPath('disabled'),
 	delegated: getPath('delegated'),
 	'delegated/disabled': getPath('delegated/disabled'),
@@ -21,7 +20,7 @@ export const paths = {
 	local: getPath('local')
 };
 
-export const editors = {
+module.exports.editors = {
 	disabled: withPath('disabled'),
 	delegated: withPath('delegated'),
 	enabled: withPath('enabled')

--- a/mocks/mock-editor.js
+++ b/mocks/mock-editor.js
@@ -1,10 +1,9 @@
-/** @babel */
-import assert from 'assert';
-import TextBuffer from 'text-buffer';
+const assert = require('assert');
+const TextBuffer = require('text-buffer');
 
 const privateSpace = new WeakMap();
 
-export default class MockEditor {
+module.exports = class MockEditor {
 	// (Object) => Object
 	constructor(options) {
 		assert(typeof options.path === 'string', msg('options.path', 'string', options.path));
@@ -31,7 +30,7 @@ export default class MockEditor {
 		const {buffer} = privateSpace.get(this);
 		return buffer.getText();
 	}
-}
+};
 
 // (name: string, value: any) => string
 function msg(name, expected, value) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 	},
 	"devDependencies": {
 		"ava": "^3.13.0",
-		"esm": "^3.2.25",
 		"proxyquire": "^2.0.1",
 		"text-buffer": "^13.15.2",
 		"tmp": "0.0.33"
@@ -51,11 +50,6 @@
 				"2.0.0": "provideLinter"
 			}
 		}
-	},
-	"ava": {
-		"require": [
-			"esm"
-		]
 	},
 	"xo": {
 		"globals": [


### PR DESCRIPTION
This keeps the package simple, by not needing to compile any syntax