### PR TITLE
Refactor lint

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports.activate = function () {
 				return;
 			}
 
-			fix(editor)(editor.getText());
+			fix(editor, lint)(editor.getText());
 		}
 	}));
 
@@ -41,7 +41,7 @@ module.exports.activate = function () {
 				return;
 			}
 
-			return fix(editor)(editor.getText(), atom.config.get('linter-xo.rulesToDisableWhileFixingOnSave'));
+			return fix(editor, lint)(editor.getText(), atom.config.get('linter-xo.rulesToDisableWhileFixingOnSave'));
 		});
 	}));
 };
@@ -77,7 +77,7 @@ module.exports.provideLinter = function () {
 		scope: 'file',
 		lintsOnChange: true,
 		lint: async editor => {
-			const result = await lint(editor)(editor.getText());
+			const result = await lint(editor.getPath())(editor.getText());
 			return format(editor)(result);
 		}
 	};

--- a/lib/fix.js
+++ b/lib/fix.js
@@ -1,11 +1,9 @@
-const lint = require('./lint');
-
 // (editor: Object) => function
-function fix(editor) {
+function fix(editor, lint) {
 	// (text: string) => Promise<void>
 	return async (text, exclude) => {
 		const fix = exclude ? report => !exclude.includes(report.ruleId) : true;
-		const report = await lint(editor)(text, {fix});
+		const report = await lint(editor.getPath())(text, {fix});
 		const [result] = report.results;
 
 		// No results are returned when the file is ignored

--- a/lib/fix.test.js
+++ b/lib/fix.test.js
@@ -1,11 +1,12 @@
 const test = require('ava');
 const {editors} = require('../mocks/index.js');
 const fix = require('./fix.js');
+const lint = require('./lint.js');
 
 test('fix file without problems', async t => {
 	const input = 'console.log(\'No problems.\');\n';
 	const editor = editors.enabled(input);
-	await fix(editor)(editor.getText());
+	await fix(editor, lint)(editor.getText());
 	const actual = editor.getText();
 	t.is(actual, input, 'should leave input untouched');
 });
@@ -13,7 +14,7 @@ test('fix file without problems', async t => {
 test('fix file with problems', async t => {
 	const input = 'console.log(\'Some problems.\');;;';
 	const editor = editors.enabled(input);
-	await fix(editor)(editor.getText());
+	await fix(editor, lint)(editor.getText());
 	const actual = editor.getText();
 	const expected = 'console.log(\'Some problems.\');\n';
 	t.is(actual, expected, 'should fix output');
@@ -22,7 +23,7 @@ test('fix file with problems', async t => {
 test('exclude rules from fixing', async t => {
 	const input = '//some uncapitalized comment';
 	const editor = editors.enabled(input);
-	await fix(editor)(editor.getText(), ['capitalized-comments']);
+	await fix(editor, lint)(editor.getText(), ['capitalized-comments']);
 	const actual = editor.getText();
 	const expected = '// some uncapitalized comment\n';
 	t.is(actual, expected, 'should fix output, but not capitalized the comment');

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -47,7 +47,7 @@ function lint(filename) {
 		// Ugly hack to workaround ESLint's lack of a `cwd` option
 		// TODO: remove this when https://github.com/sindresorhus/atom-linter-xo/issues/19 is resolved
 		const previous = process.cwd();
-		process.chdir(fileDirectory);
+		process.chdir(cwd);
 
 		let report = EMPTY_REPORT;
 		try {

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const pProps = require('p-props');
 const getPackageData = require('./get-package-data');
 const getPackagePath = require('./get-package-path');
 const getXO = require('./get-xo');
@@ -12,34 +11,34 @@ const EMPTY_REPORT = {
 	]
 };
 
+async function getCWD(base) {
+	const pkgPath = await getPackagePath(base);
+	return pkgPath ? path.dirname(pkgPath) : base;
+}
+
 // (base: string) => depends: Promise<Boolean>
 async function dependsOnXO(base) {
 	const {dependencies = {}, devDependencies = {}} = await getPackageData(base);
 	return 'xo' in dependencies || 'xo' in devDependencies;
 }
 
-// (editor: Object) => function
-function lint(editor) {
-	const filename = editor.getPath();
-
+// (filename: string) => function
+function lint(filename) {
 	if (!filename) {
 		return async () => EMPTY_REPORT;
 	}
 
-	const cwd = path.dirname(filename);
+	const fileDirectory = path.dirname(filename);
 
-	const pendingContext = pProps({
-		cwd: (async () => {
-			const pkgPath = await getPackagePath(cwd);
-			return pkgPath ? path.dirname(pkgPath) : cwd;
-		})(),
-		depends: dependsOnXO(cwd),
-		xo: getXO(cwd)
-	});
+	const pendingContext = Promise.all([
+		getCWD(fileDirectory),
+		dependsOnXO(fileDirectory),
+		getXO(fileDirectory)
+	]);
 
-	// (source: string, options?: Object) => Promise<Object>
-	return async (source, options) => {
-		const {cwd, depends, xo} = await pendingContext;
+	// (editorText: string, options?: Object) => Promise<Object>
+	return async (editorText, options) => {
+		const [cwd, depends, xo] = await pendingContext;
 
 		if (!depends) {
 			return EMPTY_REPORT;
@@ -48,12 +47,12 @@ function lint(editor) {
 		// Ugly hack to workaround ESLint's lack of a `cwd` option
 		// TODO: remove this when https://github.com/sindresorhus/atom-linter-xo/issues/19 is resolved
 		const previous = process.cwd();
-		process.chdir(cwd);
+		process.chdir(fileDirectory);
 
 		let report = EMPTY_REPORT;
 		try {
-			report = xo.lintText(source, {
-				cwd: path.dirname(editor.getPath()),
+			report = xo.lintText(editorText, {
+				cwd: fileDirectory,
 				...(filename ? {filename, cwd} : {}),
 				...options
 			});

--- a/lib/lint.test.js
+++ b/lib/lint.test.js
@@ -4,24 +4,24 @@ const lint = require('./lint.js');
 
 test('file without problems', async t => {
 	const editor = editors.enabled('console.log(\'No problems.\');\n');
-	const {results: [{messages}]} = await lint(editor)(editor.getText());
+	const {results: [{messages}]} = await lint(editor.getPath())(editor.getText());
 	t.deepEqual(messages, [], 'it should report no errors');
 });
 
 test('file with a problem', async t => {
 	const editor = editors.enabled('console.log(\'One problem\');');
-	const {results: [{messages}]} = await lint(editor)(editor.getText());
+	const {results: [{messages}]} = await lint(editor.getPath())(editor.getText());
 	t.is(messages.length, 1, 'it should report one error if enabled');
 });
 
 test('file with a problem in delegated workspace', async t => {
 	const editor = editors.delegated('console.log(\'One problem\');');
-	const {results: [{messages}]} = await lint(editor)(editor.getText());
+	const {results: [{messages}]} = await lint(editor.getPath())(editor.getText());
 	t.is(messages.length, 1, 'it should report one error if delegated');
 });
 
 test('file with a problem in disabled workspace', async t => {
 	const editor = editors.disabled('console.log(\'One problem\');');
-	const {results: [{messages}]} = await lint(editor)(editor.getText());
+	const {results: [{messages}]} = await lint(editor.getPath())(editor.getText());
 	t.is(messages.length, 0, 'it should report no errors');
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"atom-package-deps": "^5.0.0",
 		"eslint-rule-documentation": "^1.0.0",
 		"load-json-file": "^5.1.0",
-		"p-props": "^1.0.0",
 		"pkg-up": "^3.1.0",
 		"resolve-from": "^4.0.0",
 		"xo": "^0.39.0"

--- a/spec/linter-xo-spec.js
+++ b/spec/linter-xo-spec.js
@@ -83,7 +83,7 @@ describe('xo provider for linter', () => {
 			atom.config.set('linter-xo.fixOnSave', true);
 			const expected = '// uncapitalized comment\n';
 			const editor = await atom.workspace.open(files.saveFixableDefault);
-			editor.save();
+			await editor.save();
 
 			const actual = editor.getText();
 			expect(actual).toBe(expected);
@@ -97,7 +97,7 @@ describe('xo provider for linter', () => {
 			atom.config.set('linter-xo.rulesToDisableWhileFixingOnSave', ['spaced-comment']);
 			const expected = '//Uncapitalized comment\n';
 			const editor = await atom.workspace.open(files.saveFixable);
-			editor.save();
+			await editor.save();
 
 			const actual = editor.getText();
 			expect(actual).toBe(expected);


### PR DESCRIPTION
When using a [`Task`](https://flight-manual.atom.io/api/v1.57.0/Task/) we can't reference the `atom` module or global property from within the child process.

This removes references to atom from the lint function, including references to the text editor